### PR TITLE
Remove extra space in battery output

### DIFF
--- a/stmx.tests/Commands/BatteryCommandTest.cs
+++ b/stmx.tests/Commands/BatteryCommandTest.cs
@@ -46,7 +46,7 @@ public class BatteryCommandTests
 
         await cmd.ExecuteAsync(showIcon: false, showStatusIcon: false, showPercent: false);
 
-        Assert.That(consoleOut.ToString(), Is.EqualTo(" "));
+        Assert.That(consoleOut.ToString(), Is.EqualTo(""));
     }
 
     [Test]

--- a/stmx/Commands/BatteryCommand.cs
+++ b/stmx/Commands/BatteryCommand.cs
@@ -52,10 +52,9 @@ class BatteryCommand : Command
         if (batteryStatus.HasValue)
             batteryStatusIcon = showStatusIcon ? await _icons.GetBatteryStatusIcon(batteryStatus.Value) : "";
 
-
-
+        string spacing = showIcon || showStatusIcon ? " ": "";
         Console.Write(
-            $"{batteryCapacityIcon}{batteryStatusIcon} {batteryCapacity}{percentIcon}"
+            $"{batteryCapacityIcon}{batteryStatusIcon}{spacing}{batteryCapacity}{percentIcon}"
         );
     }
 }


### PR DESCRIPTION
Remove extra space before value in battery command output when no icons have to be displayed